### PR TITLE
Adding package to pypi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
+build
+dist
+*egg-info
+*.egg
 *.pyc
 *.png

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 Nina Miolane
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # geomstats
 [![Build Status](https://travis-ci.org/ninamiolane/geomstats.svg?branch=master)](https://travis-ci.org/ninamiolane/geomstats)  [![Coverage Status](https://codecov.io/gh/ninamiolane/geomstats/branch/master/graph/badge.svg)](https://codecov.io/gh/ninamiolane/geomstats)
 
-Computations and statistics on Lie groups of 3D rotations and 3D rigid transformations.
+Computations and statistics on manifolds with geometric structures such as (pseudo-/sub-) Riemannian manifolds, Lie groups, quotient spaces, etc.

--- a/geomstats/__init__.py
+++ b/geomstats/__init__.py
@@ -1,0 +1,5 @@
+import geomstats.hyperbolic_space
+import geomstats.rigid_transformations
+import geomstats.rotations
+import geomstats.sphere
+import geomstats.symmetric_positive_definite_matrices

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,11 @@
 from setuptools import setup
 
-version = '1.0'
-
 setup(name='geomstats',
-      version=version,
+      version='0.1',
+      description='Geometric statistics on manifolds',
+      url='http://github.com/ninamiolane/geomstats',
       author='Nina Miolane',
-      packages=['geomstats'])
+      author_email='ninamio78@gmail.com',
+      license='MIT',
+      packages=['geomstats'],
+      zip_safe=False)


### PR DESCRIPTION
Make the module geomstats available with pip, with MIT open source license.