### PR TITLE
Nina jacobian n

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 Computations and statistics on manifolds with geometric structures such as (pseudo-/sub-) Riemannian manifolds, Lie groups, quotient spaces, etc.
 
-<img src="https://raw.githubusercontent.com/ninamiolane/geomstats/master/examples/imgs/gradient_descent.gif" width=256 height=256><img src="https://raw.githubusercontent.com/ninamiolane/geomstats/master/examples/imgs/h2_grid.png" width=256 height=256>
+<img src="https://raw.githubusercontent.com/ninamiolane/geomstats/master/examples/imgs/gradient_descent.gif" width=384 height=384><img src="https://raw.githubusercontent.com/ninamiolane/geomstats/master/examples/imgs/h2_grid.png" width=256 height=256>
 
 
 ## Installation

--- a/geomstats/embedded_manifold.py
+++ b/geomstats/embedded_manifold.py
@@ -13,6 +13,7 @@ class EmbeddedManifold(Manifold):
     """
 
     def __init__(self, dimension, embedding_manifold):
+        assert isinstance(dimension, int) and dimension > 0
         super(EmbeddedManifold, self).__init__(
             dimension=dimension)
         self.embedding_manifold = embedding_manifold

--- a/geomstats/euclidean_space.py
+++ b/geomstats/euclidean_space.py
@@ -13,7 +13,7 @@ class EuclideanSpace(Manifold):
     """The Euclidean space."""
 
     def __init__(self, dimension):
-        assert dimension > 0
+        assert isinstance(dimension, int) and dimension > 0
         self.dimension = dimension
         self.metric = EuclideanMetric(dimension)
 
@@ -41,6 +41,7 @@ class EuclideanMetric(RiemannianMetric):
     The metric has signature (0, n) on the n-D vector space.
     """
     def __init__(self, dimension):
+        assert isinstance(dimension, int) and dimension > 0
         super(EuclideanMetric, self).__init__(
                                         dimension=dimension,
                                         signature=(dimension, 0, 0))

--- a/geomstats/euclidean_space.py
+++ b/geomstats/euclidean_space.py
@@ -13,6 +13,7 @@ class EuclideanSpace(Manifold):
     """The Euclidean space."""
 
     def __init__(self, dimension):
+        assert dimension > 0
         self.dimension = dimension
         self.metric = EuclideanMetric(dimension)
 

--- a/geomstats/general_linear_group.py
+++ b/geomstats/general_linear_group.py
@@ -23,7 +23,7 @@ class GeneralLinearGroup(LieGroup):
     """
 
     def __init__(self, n):
-        assert n > 0
+        assert isinstance(n, int) and n > 0
         super(GeneralLinearGroup, self).__init__(
                                       dimension=n*n,
                                       identity=np.eye(n))

--- a/geomstats/general_linear_group.py
+++ b/geomstats/general_linear_group.py
@@ -23,6 +23,7 @@ class GeneralLinearGroup(LieGroup):
     """
 
     def __init__(self, n):
+        assert n > 0
         super(GeneralLinearGroup, self).__init__(
                                       dimension=n*n,
                                       identity=np.eye(n))

--- a/geomstats/hyperbolic_space.py
+++ b/geomstats/hyperbolic_space.py
@@ -48,7 +48,7 @@ class HyperbolicSpace(EmbeddedManifold):
     """
 
     def __init__(self, dimension):
-        assert dimension > 0
+        assert isinstance(dimension, int) and dimension > 0
         super(HyperbolicSpace, self).__init__(
                 dimension=dimension,
                 embedding_manifold=MinkowskiSpace(dimension+1))

--- a/geomstats/hyperbolic_space.py
+++ b/geomstats/hyperbolic_space.py
@@ -48,6 +48,7 @@ class HyperbolicSpace(EmbeddedManifold):
     """
 
     def __init__(self, dimension):
+        assert dimension > 0
         super(HyperbolicSpace, self).__init__(
                 dimension=dimension,
                 embedding_manifold=MinkowskiSpace(dimension+1))

--- a/geomstats/hypersphere.py
+++ b/geomstats/hypersphere.py
@@ -35,6 +35,7 @@ class Hypersphere(EmbeddedManifold):
     """Hypersphere embedded in Euclidean space."""
 
     def __init__(self, dimension):
+        assert dimension > 0
         super(Hypersphere, self).__init__(
                 dimension=dimension,
                 embedding_manifold=EuclideanSpace(dimension+1))

--- a/geomstats/hypersphere.py
+++ b/geomstats/hypersphere.py
@@ -35,7 +35,7 @@ class Hypersphere(EmbeddedManifold):
     """Hypersphere embedded in Euclidean space."""
 
     def __init__(self, dimension):
-        assert dimension > 0
+        assert isinstance(dimension, int) and dimension > 0
         super(Hypersphere, self).__init__(
                 dimension=dimension,
                 embedding_manifold=EuclideanSpace(dimension+1))

--- a/geomstats/invariant_metric.py
+++ b/geomstats/invariant_metric.py
@@ -61,7 +61,7 @@ class InvariantMetric(RiemannianMetric):
             tangent_vec_b = vectorization.to_ndarray(tangent_vec_b, to_ndim=2)
 
             aux_vec_a = np.matmul(np.transpose(tangent_vec_a),
-                                  self.inner_product_mat_at_id)
+                                  self.inner_product_mat_at_identity)
             inner_prod = np.matmul(aux_vec_a, tangent_vec_b)
 
         elif self.group.point_representation == 'matrix':

--- a/geomstats/invariant_metric.py
+++ b/geomstats/invariant_metric.py
@@ -45,6 +45,20 @@ class InvariantMetric(RiemannianMetric):
         self.left_or_right = left_or_right
         self.signature = (n_pos_eigval, n_null_eigval, n_neg_eigval)
 
+    def inner_product_at_identity(self, tangent_vec_a, tangent_vec_b):
+        """
+        Inner product between two tangent vectors at the identity of the
+        Lie group.
+        Note: tangent vectors are given in vector representation.
+        """
+        tangent_vec_a = vectorization.to_ndarray(tangent_vec_a, to_ndim=2)
+        tangent_vec_b = vectorization.to_ndarray(tangent_vec_b, to_ndim=2)
+
+        aux_vec_a = np.matmul(np.transpose(tangent_vec_a),
+                              self.inner_product_mat_at_id)
+        inner_prod = np.matmul(aux_vec_a, tangent_vec_b)
+        return inner_prod
+
     def inner_product_matrix(self, base_point=None):
         """
         Compute the matrix of the Riemmanian metric at point base_point,

--- a/geomstats/invariant_metric.py
+++ b/geomstats/invariant_metric.py
@@ -8,6 +8,7 @@ Note: Assume that the points are parameterized by
 their Riemannian logarithm for the canonical left-invariant metric.
 """
 
+import logging
 import numpy as np
 import scipy.linalg
 
@@ -21,7 +22,8 @@ class InvariantMetric(RiemannianMetric):
     that can be defined on Lie groups.
     """
 
-    def __init__(self, group, inner_product_mat_at_identity,
+    def __init__(self, group,
+                 inner_product_mat_at_identity=None,
                  left_or_right='left'):
         if inner_product_mat_at_identity.ndim == 3:
             n_mats, _, _ = inner_product_mat_at_identity.shape
@@ -41,6 +43,9 @@ class InvariantMetric(RiemannianMetric):
                 + n_null_eigval) == group.dimension
 
         self.group = group
+        if inner_product_mat_at_identity is None:
+            inner_product_mat_at_identity = np.eye(self.group.dimension)
+
         self.inner_product_mat_at_identity = inner_product_mat_at_identity
         self.left_or_right = left_or_right
         self.signature = (n_pos_eigval, n_null_eigval, n_neg_eigval)
@@ -51,12 +56,46 @@ class InvariantMetric(RiemannianMetric):
         Lie group.
         Note: tangent vectors are given in vector representation.
         """
-        tangent_vec_a = vectorization.to_ndarray(tangent_vec_a, to_ndim=2)
-        tangent_vec_b = vectorization.to_ndarray(tangent_vec_b, to_ndim=2)
+        if self.group.point_representation == 'vector':
+            tangent_vec_a = vectorization.to_ndarray(tangent_vec_a, to_ndim=2)
+            tangent_vec_b = vectorization.to_ndarray(tangent_vec_b, to_ndim=2)
 
-        aux_vec_a = np.matmul(np.transpose(tangent_vec_a),
-                              self.inner_product_mat_at_id)
-        inner_prod = np.matmul(aux_vec_a, tangent_vec_b)
+            aux_vec_a = np.matmul(np.transpose(tangent_vec_a),
+                                  self.inner_product_mat_at_id)
+            inner_prod = np.matmul(aux_vec_a, tangent_vec_b)
+
+        elif self.group.point_representation == 'matrix':
+            logging.warning(
+                'Only the canonical inner product -Frobenius inner product-'
+                ' is implemented for Lie groups whose elements are represented'
+                ' by matrices.')
+            tangent_vec_a = vectorization.to_ndarray(tangent_vec_a, to_ndim=3)
+            tangent_vec_b = vectorization.to_ndarray(tangent_vec_b, to_ndim=3)
+            aux_prod = np.matmul(np.transpose(tangent_vec_a, axes=(0, 2, 1)),
+                                 tangent_vec_b)
+            inner_prod = np.trace(aux_prod)
+
+        return inner_prod
+
+    def inner_product(self, tangent_vec_a, tangent_vec_b, base_point=None):
+        if base_point is None:
+            return self.inner_product_at_identity(tangent_vec_a,
+                                                  tangent_vec_b)
+        if self.group.point_representation == 'vector':
+                return super(InvariantMetric, self).inner_product(
+                                     tangent_vec_a,
+                                     tangent_vec_b,
+                                     base_point)
+
+        if self.left_or_right == 'right':
+            raise NotImplementedError(
+                'inner_product not implemented for right invariant metrics.')
+        jacobian = self.group.jacobian_translation(base_point)
+        inv_jacobian = np.linalg.inv(jacobian)
+        tangent_vec_a_at_id = np.matmul(inv_jacobian, tangent_vec_a)
+        tangent_vec_b_at_id = np.matmul(inv_jacobian, tangent_vec_b)
+        inner_prod = self.inner_product_at_identity(tangent_vec_a_at_id,
+                                                    tangent_vec_b_at_id)
         return inner_prod
 
     def inner_product_matrix(self, base_point=None):
@@ -64,6 +103,11 @@ class InvariantMetric(RiemannianMetric):
         Compute the matrix of the Riemmanian metric at point base_point,
         by translating inner_product from the identity to base_point.
         """
+        if self.group.point_representation == 'matrix':
+            raise NotImplementedError(
+                'inner_product_matrix not implemented for Lie groups'
+                ' whose elements are represented as matrices.')
+
         if base_point is None:
             base_point = self.group.identity
         base_point = self.group.regularize(base_point)

--- a/geomstats/invariant_metric.py
+++ b/geomstats/invariant_metric.py
@@ -56,13 +56,17 @@ class InvariantMetric(RiemannianMetric):
         Lie group.
         Note: tangent vectors are given in vector representation.
         """
+        assert self.group.point_representation in ('vector', 'matrix')
+
         if self.group.point_representation == 'vector':
             tangent_vec_a = vectorization.to_ndarray(tangent_vec_a, to_ndim=2)
             tangent_vec_b = vectorization.to_ndarray(tangent_vec_b, to_ndim=2)
 
-            aux_vec_a = np.matmul(np.transpose(tangent_vec_a),
+            aux_vec_a = np.matmul(tangent_vec_a,
                                   self.inner_product_mat_at_identity)
-            inner_prod = np.matmul(aux_vec_a, tangent_vec_b)
+            inner_prod = np.einsum('ij,ij->i', aux_vec_a, tangent_vec_b)
+            inner_prod = vectorization.to_ndarray(inner_prod,
+                                                  to_ndim=2, axis=1)
 
         elif self.group.point_representation == 'matrix':
             logging.warning(

--- a/geomstats/lie_group.py
+++ b/geomstats/lie_group.py
@@ -11,6 +11,7 @@ class LieGroup(Manifold):
     """ Base class for Lie groups."""
 
     def __init__(self, dimension, identity):
+        assert dimension > 0
         Manifold.__init__(self, dimension)
         self.identity = identity
 

--- a/geomstats/manifold.py
+++ b/geomstats/manifold.py
@@ -7,7 +7,7 @@ class Manifold(object):
     """Base class for differentiable manifolds."""
 
     def __init__(self, dimension):
-        assert dimension > 0
+        assert isinstance(dimension, int) and dimension > 0
         self.dimension = dimension
 
     def belongs(self, point):

--- a/geomstats/manifold.py
+++ b/geomstats/manifold.py
@@ -7,6 +7,7 @@ class Manifold(object):
     """Base class for differentiable manifolds."""
 
     def __init__(self, dimension):
+        assert dimension > 0
         self.dimension = dimension
 
     def belongs(self, point):

--- a/geomstats/matrices_spaces.py
+++ b/geomstats/matrices_spaces.py
@@ -13,7 +13,7 @@ class MatrixSpace(EuclideanSpace):
     """The space of matrices (m, n)."""
 
     def __init__(self, m, n):
-        assert m > 0 & n > 0
+        assert isinstance(m, int) and isinstance(n, int) and m > 0 and n > 0
         super().init(dimension=m*n)
         self.m = m
         self.n = n

--- a/geomstats/matrices_spaces.py
+++ b/geomstats/matrices_spaces.py
@@ -1,0 +1,35 @@
+"""
+The space of matrices (m, n), which is the Euclidean space
+R^{mn}.
+"""
+
+import numpy as np
+
+from geomstats.euclidean_space import EuclideanSpace
+import geomstats.vectorization as vectorization
+
+
+class MatrixSpace(EuclideanSpace):
+    """The space of matrices (m, n)."""
+
+    def __init__(self, m, n):
+        assert m > 0 & n > 0
+        super().init(dimension=m*n)
+        self.m = m
+        self.n = n
+
+    def belongs(self, point):
+        """
+        Check if point belongs to the Matrix space.
+        """
+        point = vectorization.to_ndarray(point, to_ndim=3)
+        _, mat_dim_1, mat_dim_2 = point.shape
+        return mat_dim_1 == self.m & mat_dim_2 == self.n
+
+    def vector_from_matrix(self, matrix):
+        """
+        Conversion function from (_, m, n) to (_, mn).
+        """
+        matrix = vectorization.to_ndarray(matrix, to_ndim=3)
+        n_mats, m, n = matrix.shape
+        return np.reshape(matrix, (n_mats, m*n))

--- a/geomstats/minkowski_space.py
+++ b/geomstats/minkowski_space.py
@@ -13,6 +13,7 @@ class MinkowskiSpace(Manifold):
     """The Minkowski Space."""
 
     def __init__(self, dimension):
+        assert dimension > 0
         self.dimension = dimension
         self.metric = MinkowskiMetric(dimension)
 

--- a/geomstats/minkowski_space.py
+++ b/geomstats/minkowski_space.py
@@ -13,7 +13,7 @@ class MinkowskiSpace(Manifold):
     """The Minkowski Space."""
 
     def __init__(self, dimension):
-        assert dimension > 0
+        assert isinstance(dimension, int) and dimension > 0
         self.dimension = dimension
         self.metric = MinkowskiMetric(dimension)
 

--- a/geomstats/riemannian_metric.py
+++ b/geomstats/riemannian_metric.py
@@ -17,7 +17,7 @@ class RiemannianMetric(object):
     """
 
     def __init__(self, dimension, signature=None):
-        assert dimension > 0
+        assert isinstance(dimension, int) and dimension > 0
         self.dimension = dimension
         if signature is not None:
             assert np.sum(signature) == dimension

--- a/geomstats/spd_matrices_space.py
+++ b/geomstats/spd_matrices_space.py
@@ -84,7 +84,7 @@ def group_log(sym_mat):
 
 class SPDMatricesSpace(EmbeddedManifold):
     def __init__(self, n):
-        assert n > 0
+        assert isinstance(n, int) and n > 0
         super(SPDMatricesSpace, self).__init__(
             dimension=int(n * (n + 1) / 2),
             embedding_manifold=GeneralLinearGroup(n=n))

--- a/geomstats/spd_matrices_space.py
+++ b/geomstats/spd_matrices_space.py
@@ -84,6 +84,7 @@ def group_log(sym_mat):
 
 class SPDMatricesSpace(EmbeddedManifold):
     def __init__(self, n):
+        assert n > 0
         super(SPDMatricesSpace, self).__init__(
             dimension=int(n * (n + 1) / 2),
             embedding_manifold=GeneralLinearGroup(n=n))

--- a/geomstats/special_euclidean_group.py
+++ b/geomstats/special_euclidean_group.py
@@ -36,6 +36,7 @@ class SpecialEuclideanGroup(LieGroup):
         # TODO(nina): keep the names rotations and translations here?
         self.rotations = SpecialOrthogonalGroup(n=n)
         self.translations = EuclideanSpace(dimension=n)
+        self.point_representation = 'vector' if n == 3 else 'matrix'
 
     def belongs(self, point):
         """

--- a/geomstats/special_euclidean_group.py
+++ b/geomstats/special_euclidean_group.py
@@ -23,7 +23,7 @@ PI8 = PI * PI7
 class SpecialEuclideanGroup(LieGroup):
 
     def __init__(self, n):
-        assert n > 1
+        assert isinstance(n, int) and n > 1
 
         if n is not 3:
             raise NotImplementedError('Only SE(3) is implemented.')

--- a/geomstats/special_orthogonal_group.py
+++ b/geomstats/special_orthogonal_group.py
@@ -529,58 +529,63 @@ class SpecialOrthogonalGroup(LieGroup, EmbeddedManifold):
         :param rot_vec: 3D rotation vector
         :returns jacobian: 3x3 matrix
         """
-        if self.n != 3:
-            raise NotImplementedError(
-                'jacobian_translation not implemented for n != 3.')
-
         assert self.belongs(point)
         assert left_or_right in ('left', 'right')
-        point = self.regularize(point)
-        n_points, _ = point.shape
 
-        angle = np.linalg.norm(point, axis=1)
-        angle = np.expand_dims(angle, axis=1)
+        if self.n == 3:
+            point = self.regularize(point)
+            n_points, _ = point.shape
 
-        coef_1 = np.zeros([n_points, 1])
-        coef_2 = np.zeros([n_points, 1])
+            angle = np.linalg.norm(point, axis=1)
+            angle = np.expand_dims(angle, axis=1)
 
-        mask_0 = np.isclose(angle, 0)
-        mask_0 = np.squeeze(mask_0, axis=1)
-        coef_1[mask_0] = (1 - angle[mask_0] ** 2 / 12
-                          - angle[mask_0] ** 4 / 720
-                          - angle[mask_0] ** 6 / 30240)
-        coef_2[mask_0] = (1 / 12 + angle[mask_0] ** 2 / 720
-                          + angle[mask_0] ** 4 / 30240
-                          + angle[mask_0] ** 6 / 1209600)
+            coef_1 = np.zeros([n_points, 1])
+            coef_2 = np.zeros([n_points, 1])
 
-        mask_pi = np.isclose(angle, np.pi)
-        mask_pi = np.squeeze(mask_pi, axis=1)
-        delta_angle = angle[mask_pi] - np.pi
-        coef_1[mask_pi] = (- np.pi * delta_angle / 4
-                           - delta_angle ** 2 / 4
-                           - np.pi * delta_angle ** 3 / 48
-                           - delta_angle ** 4 / 48
-                           - np.pi * delta_angle ** 5 / 480
-                           - delta_angle ** 6 / 480)
-        coef_2[mask_pi] = (1 - coef_1[mask_pi]) / angle[mask_pi] ** 2
+            mask_0 = np.isclose(angle, 0)
+            mask_0 = np.squeeze(mask_0, axis=1)
+            coef_1[mask_0] = (1 - angle[mask_0] ** 2 / 12
+                              - angle[mask_0] ** 4 / 720
+                              - angle[mask_0] ** 6 / 30240)
+            coef_2[mask_0] = (1 / 12 + angle[mask_0] ** 2 / 720
+                              + angle[mask_0] ** 4 / 30240
+                              + angle[mask_0] ** 6 / 1209600)
 
-        mask_else = ~mask_0 & ~mask_pi
-        coef_1[mask_else] = ((angle[mask_else] / 2)
-                             / np.tan(angle[mask_else] / 2))
-        coef_2[mask_else] = (1 - coef_1[mask_else]) / angle[mask_else] ** 2
+            mask_pi = np.isclose(angle, np.pi)
+            mask_pi = np.squeeze(mask_pi, axis=1)
+            delta_angle = angle[mask_pi] - np.pi
+            coef_1[mask_pi] = (- np.pi * delta_angle / 4
+                               - delta_angle ** 2 / 4
+                               - np.pi * delta_angle ** 3 / 48
+                               - delta_angle ** 4 / 48
+                               - np.pi * delta_angle ** 5 / 480
+                               - delta_angle ** 6 / 480)
+            coef_2[mask_pi] = (1 - coef_1[mask_pi]) / angle[mask_pi] ** 2
 
-        jacobian = np.zeros((n_points, self.dimension, self.dimension))
+            mask_else = ~mask_0 & ~mask_pi
+            coef_1[mask_else] = ((angle[mask_else] / 2)
+                                 / np.tan(angle[mask_else] / 2))
+            coef_2[mask_else] = (1 - coef_1[mask_else]) / angle[mask_else] ** 2
 
-        for i in range(n_points):
-            if left_or_right == 'left':
-                jacobian[i] = (coef_1[i] * np.identity(self.dimension)
-                               + coef_2[i] * np.outer(point[i], point[i])
-                               + skew_matrix_from_vector(point[i]) / 2)
+            jacobian = np.zeros((n_points, self.dimension, self.dimension))
 
-            else:
-                jacobian[i] = (coef_1[i] * np.identity(self.dimension)
-                               + coef_2[i] * np.outer(point[i], point[i])
-                               - skew_matrix_from_vector(point[i]) / 2)
+            for i in range(n_points):
+                if left_or_right == 'left':
+                    jacobian[i] = (coef_1[i] * np.identity(self.dimension)
+                                   + coef_2[i] * np.outer(point[i], point[i])
+                                   + skew_matrix_from_vector(point[i]) / 2)
+
+                else:
+                    jacobian[i] = (coef_1[i] * np.identity(self.dimension)
+                                   + coef_2[i] * np.outer(point[i], point[i])
+                                   - skew_matrix_from_vector(point[i]) / 2)
+
+        else:
+            if left_or_right == 'right':
+                raise NotImplementedError(
+                    'The jacobian of the right translation'
+                    ' is not implemented.')
+            jacobian = self.matrix_from_rotation_vector(point)
 
         assert jacobian.ndim == 3
         return jacobian

--- a/geomstats/special_orthogonal_group.py
+++ b/geomstats/special_orthogonal_group.py
@@ -116,7 +116,7 @@ def vector_from_skew_matrix(skew_mat):
 class SpecialOrthogonalGroup(LieGroup, EmbeddedManifold):
 
     def __init__(self, n):
-        assert n > 1
+        assert isinstance(n, int) and n > 1
 
         self.n = n
         self.dimension = int((n * (n - 1)) / 2)

--- a/geomstats/special_orthogonal_group.py
+++ b/geomstats/special_orthogonal_group.py
@@ -127,6 +127,7 @@ class SpecialOrthogonalGroup(LieGroup, EmbeddedManifold):
                                   dimension=self.dimension,
                                   embedding_manifold=GeneralLinearGroup(n=n))
         self.bi_invariant_metric = self.left_canonical_metric
+        self.point_representation = 'vector' if n == 3 else 'matrix'
 
     def belongs(self, rot_vec):
         """

--- a/geomstats/special_orthogonal_group.py
+++ b/geomstats/special_orthogonal_group.py
@@ -180,10 +180,12 @@ class SpecialOrthogonalGroup(LieGroup, EmbeddedManifold):
         determined by the metric, to be less than pi,
         following the regularization convention.
         """
-        tangent_vec = vectorization.to_ndarray(tangent_vec, to_ndim=2)
-        _, vec_dim = tangent_vec.shape
+        assert self.point_representation in ('vector', 'matrix')
 
-        if vec_dim == 3:
+        if self.point_representation is 'vector':
+            tangent_vec = vectorization.to_ndarray(tangent_vec, to_ndim=2)
+            _, vec_dim = tangent_vec.shape
+
             if metric is None:
                 metric = self.left_canonical_metric
             tangent_vec_metric_norm = metric.norm(tangent_vec)

--- a/tests/test_manifold.py
+++ b/tests/test_manifold.py
@@ -10,7 +10,7 @@ class TestManifoldMethods(unittest.TestCase):
     _multiprocess_can_split_ = True
 
     def setUp(self):
-        self.dimension = np.random.randint(1)
+        self.dimension = np.random.randint(low=1, high=10)
         self.manifold = Manifold(self.dimension)
 
     def test_dimension(self):


### PR DESCRIPTION
Add asserts to check that the dimension's and n's initiating manifolds and groups are integers and > 0 (or > 1 depending on the cases).

Add the `point_representation` attribute to SO(n) and SE(n) to distinguish the cases where the elements of the groups are represented as vectors or as matrices (for geomstats' inner computations).

When elements are represented as vectors (`point_representation='vector'`), computing an inner product is done by x^T.Z.y where Z is the matrix corresponding to the inner product. When elements are represented as matrices, we implement a method that performs the inner_product on the matrices directly. I add the methods `inner_product` and `inner_product_at_identity` for this purpose.

Add the jacobian for SO(n).